### PR TITLE
:art: Add Example of Usage - IGC

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,18 +13,21 @@ The Icelandic Corpora Toolkit
 <!-- Logo using: -->
 <!-- <div>Icons made by <a href="https://www.flaticon.com/authors/photo3idea-studio" title="photo3idea_studio">photo3idea_studio</a> from <a href="https://www.flaticon.com/" title="Flaticon">www.flaticon.com</a></div> -->
 
+
 ## Table of Contents
 <!-- ⛔️ MD-MAGIC-EXAMPLE:START (TOC:collapse=true&collapseText=Click to expand) -->
 <details>
 <summary>Click to expand</summary>
 
-* [Introduction](#introduction)
-* [Corpora](#corpora)
-* [Setup](#setup)
-* [Example of Usage](#example-of-usage)
-* [Contributors](#contributors)
-* [License](#license)
-* [References](#references)
+- [Table of Contents](#table-of-contents)
+- [Introduction](#introduction)
+- [Corpora](#corpora)
+- [Setup](#setup)
+- [Example of Usage](#example-of-usage)
+- [License](#license)
+- [References](#references)
+- [Contributors](#contributors)
+- [Contributing](#contributing)
 
 </details>
 <!-- ⛔️ MD-MAGIC-EXAMPLE:END -->
@@ -44,16 +47,7 @@ There are two main sources of corpora available for Icelandic:
 
 ## Example of Usage
 
-### Reading the IGC
-The IGC is distributed as a collection of .xml files in the tei format. We provide a tool to parse these files and write (some of) the content to a file.
-
-- The command takes as a first argument a file (or stdin, using `-`) with a single filepath in each line.
-- The second argument is a file to write the parsed files.
-```
-find /data/risamalheild/2018/rmh1 -type f \( -name "*.xml" -not -name "hdr?.xml" \) | \
-  ./main.py read-rmh - rmh.txt --threads 2 --chunksize 400
-```
-This will prase all `.xml` files, excluding the header files, in the directory `/data/risamalheild/2018/rmh1` using 2 threads and processing 400 files at once. The output is written to `rmh.txt`.
+* [The Icelandic Gigaword Corpus (IGC)](./examples/igc.md)
 
 ## License
 This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENSE) file for details.

--- a/examples/igc.md
+++ b/examples/igc.md
@@ -1,0 +1,49 @@
+<h1 align="center">
+Example of Usage <br/>
+The Icelandic Gigaword Corpus (IGC)
+</h1>
+
+<!-- omit in toc -->
+## Introduction
+
+The Icelandic Corpora Toolkit is a collection of scripts to use with various Icelandic text corpora. 
+
+Here below are some of the most common examples of usage.
+
+<details>
+<summary>List of all examples</summary>
+
+- [1. Extracting plain text from IGC](#1-extracting-plain-text-from-igc)
+</details>
+
+## 1. Extracting plain text from IGC
+The IGC is distributed as a collection of .xml files in the tei format. 
+ICTK provides a script that takes these files and write (some of) the content to an output file.
+
+<details>
+<summary>Terra User (A cloud cluster at LVL)</summary>
+
+- The command takes as a first argument a file (or stdin, using `-`) with a single filepath in each line.
+- The second argument is a file to write the parsed files.
+
+```consoles
+find /data/risamalheild/2018/rmh1 -type f \( -name "*.xml" -not -name "hdr?.xml" \) | ./main.py read-rmh - rmh.txt --threads 16 --chunksize 400
+```
+This will prase all `.xml` files, excluding the header files, in the directory `/data/risamalheild/2018/rmh1` using 16 threads and processing 400 files at once. The output is written to `rmh.txt`.
+
+</details>
+
+<details>
+<summary>Non-Terra User</summary>
+
+Make sure you 
+
+- The command takes as a first argument a file (or stdin, using `-`) with a single filepath in each line.
+- The second argument is the output file to write the parsed files.
+
+```consoles
+$ find rmh/ -type f \( -name "*.xml" -not -name "hdr?.xml" \) | ictk/main.py read-igc - rmh.txt --threads 2 --chunksize 400
+```
+This will prase all `.xml` files, excluding the header files, in the directory `rmh` using 2 threads and processing 400 files at once. The output is written to `rmh.txt`.
+
+</details>

--- a/ictk/igc.py
+++ b/ictk/igc.py
@@ -35,12 +35,12 @@ def get_corpus(files: List[str], threads=1, chunksize=400) -> Iterable[Corpus]:
     """
     with ProcessPoolExecutor(max_workers=threads) as executor:
         results = tqdm(
-            executor.map(get_corpus_from_file, files, chunksize=chunksize), total=len(files)
+            executor.map(get_text_from_file, files, chunksize=chunksize), total=len(files)
         )
         yield from results
 
 
-def get_corpus_from_file(path: str) -> Corpus:
+def get_text_from_file(path: str) -> Corpus:
     """Read a single IGC file and returns a Corpus.
 
     Args:

--- a/main.py
+++ b/main.py
@@ -45,7 +45,7 @@ def read_igc(input, output, threads, chunksize):
     """
     files = [line.strip() for line in input]
     log.info(f"Processing IGC. Number of files={len(files)}")
-    for corpus in igc.read_IGC(files, threads=threads, chunksize=chunksize):
+    for corpus in igc.get_corpus(files, threads=threads, chunksize=chunksize):
         for sentence in corpus:
             output.write(" ".join(sentence) + "\n")
     log.info("Done.")

--- a/tests/test_igc.py
+++ b/tests/test_igc.py
@@ -11,7 +11,7 @@ from ictk import igc
 
 def test_igc_parsing():
     """Test whether a single IGC file is parsed correctly."""
-    result = igc.get_corpus_from_file("./tests/igc_test_file.txt")
+    result = igc.get_text_from_file("./tests/igc_test_file.txt")
     # fmt: off
     assert result == (
         ("Fyrirlestraröð", "Framfara", "stendur", "fyrir", "fyrirlestri", "um", "ástæður", "ofþjálfunar", ",", "einkenni", "og", "meðferð", "."),


### PR DESCRIPTION
I have moved the context of the _Example of Usage_ section of the `READEME.md` file and moved it to a new file